### PR TITLE
Add IPC safety checks for recorder preload

### DIFF
--- a/src/renderer/overlay/overlay.tsx
+++ b/src/renderer/overlay/overlay.tsx
@@ -12,6 +12,7 @@ interface OverlayState {
   timerSec: number;
   draft?: string;
   isVisible: boolean;
+  errorMessage?: string;
   toast?: ToastMessage | null;
 }
 
@@ -21,6 +22,7 @@ const OverlayApp: React.FC = () => {
     timerSec: 0,
     draft: undefined,
     isVisible: true,
+    errorMessage: undefined,
     toast: null
   });
 
@@ -109,12 +111,13 @@ const OverlayApp: React.FC = () => {
 
     // Listen for recording state changes
     const handleRecordingStart = () => {
-      setState(prev => ({ 
-        ...prev, 
+      setState(prev => ({
+        ...prev,
         status: 'recording',
         timerSec: 0,
         draft: undefined,
         isVisible: true,
+        errorMessage: undefined,
         toast: null
       }));
     };
@@ -131,8 +134,8 @@ const OverlayApp: React.FC = () => {
       }, 800);
     };
 
-    const handleRecordingError = () => {
-      setState(prev => ({ ...prev, status: 'error' }));
+    const handleRecordingError = (event: any, msg?: string) => {
+      setState(prev => ({ ...prev, status: 'error', errorMessage: msg }));
       // Hide after showing error message for longer duration
       setTimeout(() => {
         setState(prev => ({ ...prev, isVisible: false }));
@@ -260,8 +263,8 @@ const OverlayApp: React.FC = () => {
             }}>
               ⚠ Error
             </div>
-            <div style={{ 
-              fontSize: '9px', 
+            <div style={{
+              fontSize: '9px',
               color: 'rgba(220, 53, 69, 0.7)',
               marginTop: '8px',
               textAlign: 'center',
@@ -270,7 +273,7 @@ const OverlayApp: React.FC = () => {
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap'
             }}>
-              Check microphone or network
+              {state.errorMessage ?? 'Check microphone or network'}
             </div>
           </>
         );

--- a/src/renderer/recorder/index.ts
+++ b/src/renderer/recorder/index.ts
@@ -6,6 +6,47 @@ console.log('Recorder renderer loaded');
 // Access IPC through the preload bridge
 const ipcRenderer = (window as any).electronAPI?.ipcRenderer;
 
+function showInternalIpcFailure(): void {
+  try {
+    ipcRenderer?.send?.('recording-error', 'Internal IPC failure');
+  } catch {
+    if (typeof document !== 'undefined') {
+      const container =
+        document.getElementById('recorder-root') || document.body;
+      if (container) {
+        const el = document.createElement('div');
+        el.textContent = 'Internal IPC failure';
+        el.style.cssText = 'color:red;font-family:sans-serif;padding:8px';
+        container.appendChild(el);
+      }
+    }
+  }
+}
+
+function safeSend(channel: string, ...args: any[]): void {
+  try {
+    if (!ipcRenderer || typeof ipcRenderer.send !== 'function') {
+      throw new Error('ipcRenderer unavailable');
+    }
+    ipcRenderer.send(channel, ...args);
+  } catch (error) {
+    console.error('IPC send failed:', error);
+    showInternalIpcFailure();
+  }
+}
+
+function safeOn(channel: string, listener: (...args: any[]) => void): void {
+  try {
+    if (!ipcRenderer || typeof ipcRenderer.on !== 'function') {
+      throw new Error('ipcRenderer unavailable');
+    }
+    ipcRenderer.on(channel, listener);
+  } catch (error) {
+    console.error('IPC on failed:', error);
+    showInternalIpcFailure();
+  }
+}
+
 import workletCode from './audioWorkletProcessor';
 
 let audioContext: AudioContext | null = null;
@@ -25,7 +66,7 @@ async function setupAudioHandling(): Promise<void> {
       }
     });
 
-    ipcRenderer.send('mic-permission-success');
+    safeSend('mic-permission-success');
 
     audioContext = new AudioContext({ sampleRate: 16000 });
     const blob = new Blob([workletCode], { type: 'application/javascript' });
@@ -60,16 +101,18 @@ async function setupAudioHandling(): Promise<void> {
       errorMessage = 'Microphone already in use';
     }
 
-    ipcRenderer.send('mic-permission-error', errorMessage);
+    safeSend('mic-permission-error', errorMessage);
   }
 }
 
 function handleAudioChunk(chunk: ArrayBuffer): void {
   if (chunk.byteLength > 0) {
-    ipcRenderer.send('audio-chunk', chunk);
+    safeSend('audio-chunk', chunk);
   }
 }
 
-ipcRenderer.on('start-mic-capture', () => {
+safeOn('start-mic-capture', () => {
   setupAudioHandling();
 });
+
+export const __test__ = { safeSend, safeOn, showInternalIpcFailure };

--- a/tests/recorderPreload.test.ts
+++ b/tests/recorderPreload.test.ts
@@ -1,0 +1,21 @@
+describe('Recorder preload safety', () => {
+  beforeEach(() => {
+    (global as any).window = {};
+  });
+
+  test('safeSend handles missing ipcRenderer gracefully', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    const mod = require('../src/renderer/recorder/index');
+    expect(() => mod.__test__.safeSend('test')).not.toThrow();
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  test('safeOn handles missing ipcRenderer gracefully', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    const mod = require('../src/renderer/recorder/index');
+    expect(() => mod.__test__.safeOn('test', () => {})).not.toThrow();
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- guard ipcRenderer usage in recorder renderer
- show `recording-error` when ipc is missing
- support custom error message in overlay
- test recorder IPC guards

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c253a13c4832a86ea065d4d1b53cc